### PR TITLE
mixing with premixed events in input

### DIFF
--- a/mcm/json_layer/campaign.py
+++ b/mcm/json_layer/campaign.py
@@ -97,7 +97,11 @@ class campaign(json_base):
                      else:
                          cdarg+=" --filein file:step%s.root"%(stepindex-1)
                  cdarg+=" --fileout file:step%s.root"%stepindex
+                 # the classic mixing identified by the presence of --pileup ; this is untouched
                  if self.get_attribute('pileup_dataset_name') and not (seq.get_attribute('pileup') in ['','NoPileUp']):
+                     cdarg+=' --pileup_input "dbs:%s" '%(self.get_attribute('pileup_dataset_name'))
+                 # the mixing using premixed events: absesence of --pileup and presence of datamix
+                 elif self.get_attribute('pileup_dataset_name') and (seq.get_attribute('pileup') in ['']) and (seq.get_attribute('datamix') in ['PreMix']):
                      cdarg+=' --pileup_input "dbs:%s" '%(self.get_attribute('pileup_dataset_name'))
 
                  cd='cmsDriver.py %s %s'%(fragment, cdarg)


### PR DESCRIPTION
Antanas, this is how I believe we can foresee the premixed events dataset to be put in input to the cmsDriver sequence, when we need it.
I don't have the setup to test this functionality - could you please look at it, and try import this PR into the dev ? We could look together at how it behaves.
Note that the handling of the dataset input for standard workflows has not been touched.
NOT FOR PRODUCTION.
