### PR TITLE
Registration of crab3 tasks to requests

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -451,9 +451,14 @@ class request(json_base):
                 if not all_good:
                     raise self.WrongApprovalSequence(self.get_attribute('status'), 'approve',
                                                      'The request is not the current step of chain %s and the remaining of the chain is not in the correct status' % (mcm_cr['prepid']))
-        ## start uploading the configs ?
         if not for_chain:
             self.set_status()
+        ## start uploading the configs : yes, so that one can use it right away
+        from tools.handlers import ConfigMakerAndUploader
+        load = ConfigMakerAndUploader( prepid = self.get_attribute('prepid'), 
+                                       lock = locker.lock( self.get_attribute('prepid') ))
+        load.start()
+
 
     def ok_to_move_to_approval_submit(self):
         if self.current_user_level < 3:

--- a/mcm/main.py
+++ b/mcm/main.py
@@ -1,6 +1,6 @@
 from rest_api.ControlActions import Search, MultiSearch
 from rest_api.RestAPIMethod import RESTResourceIndex, RESTResource
-from rest_api.RequestActions import ImportRequest, ManageRequest, DeleteRequest, GetRequest, GetRequestByDataset, UpdateRequest, GetCmsDriverForRequest, GetFragmentForRequest, GetSetupForRequest, ApproveRequest, UploadConfig, InjectRequest, ResetRequestApproval, SetStatus, GetStatus, GetEditable, GetDefaultGenParams, CloneRequest, RegisterUser, MigrateRequest, MigratePage, GetActors, NotifyUser, InspectStatus, UpdateStats, RequestsFromFile, TestRequest, StalledReminder, RequestsReminder, RequestPerformance, SearchableRequest, UpdateMany, GetAllRevisions, ListRequestPrepids, OptionResetForRequest, GetRequestOutput, GetInjectCommand, GetUploadCommand, GetUniqueValues
+from rest_api.RequestActions import ImportRequest, ManageRequest, DeleteRequest, GetRequest, GetRequestByDataset, UpdateRequest, GetCmsDriverForRequest, GetFragmentForRequest, GetSetupForRequest, ApproveRequest, UploadConfig, InjectRequest, ResetRequestApproval, SetStatus, GetStatus, GetEditable, GetDefaultGenParams, CloneRequest, RegisterUser, MigrateRequest, MigratePage, GetActors, NotifyUser, InspectStatus, RegisterRequestTask, UpdateStats, RequestsFromFile, TestRequest, StalledReminder, RequestsReminder, RequestPerformance, SearchableRequest, UpdateMany, GetAllRevisions, ListRequestPrepids, OptionResetForRequest, GetRequestOutput, GetInjectCommand, GetUploadCommand, GetUniqueValues
 from rest_api.CampaignActions import CreateCampaign, DeleteCampaign, UpdateCampaign, GetCampaign, ToggleCampaign, ToggleCampaignStatus, ApproveCampaign, GetAllCampaigns, GetCmsDriverForCampaign, ListAllCampaigns, InspectRequests, InspectCampaigns
 from rest_api.ChainedCampaignActions import CreateChainedCampaign, DeleteChainedCampaign, GetChainedCampaign, UpdateChainedCampaign,  GenerateChainedRequests as chained_generate_requests, InspectChainedRequests, InspectChainedCampaigns, SelectNewChainedCampaigns, ListChainCampaignPrepids
 from rest_api.ChainedRequestActions import CreateChainedRequest, UpdateChainedRequest, DeleteChainedRequest, GetChainedRequest,  FlowToNextStep,  ApproveRequest as ApproveChainedRequest, InspectChain, RewindToPreviousStep, GetConcatenatedHistory, SearchableChainedRequest, TestChainedRequest, GetSetupForChains, TaskChainDict, InjectChainedRequest
@@ -274,6 +274,8 @@ root.restapi.requests.register = RegisterUser()
 root.restapi.requests.notify = NotifyUser()
 root.restapi.requests.migrate = MigrateRequest()
 root.restapi.requests.inspect = InspectStatus()
+root.restapi.requests.registertask = RegisterRequestTask()
+root.restapi.requests.inspecttask = InspectStatus(for_task=True)
 root.restapi.requests.update_stats = UpdateStats()
 root.restapi.requests.listwithfile = RequestsFromFile()
 root.restapi.requests.test = TestRequest()

--- a/mcm/rest_api/ChainedRequestActions.py
+++ b/mcm/rest_api/ChainedRequestActions.py
@@ -532,7 +532,13 @@ class TestChainedRequest(RESTResource):
         rdb = database('requests')
         mcm_cr = chained_request(crdb.get(args[0]))
         mcm_rs = []
-        for rid in mcm_cr.get_attribute('chain'):
+        
+        for rid in mcm_cr.get_attribute('chain')[mcm_cr.get_attribute('step'):]:
+            mcm_r = request( rdb.get( rid ) )
+            if mcm_r.get_attribute('status') in ['approved','submitted','done']:
+                return dumps({"results" : False, "message" : "request %s is in status %s"%( rid, mcm_r.get_attribute('status'))})
+
+        for rid in mcm_cr.get_attribute('chain')[mcm_cr.get_attribute('step'):]:
             mcm_r = request( rdb.get( rid ) )
             next='validation'
             if not mcm_r.is_root:  next='approve'

--- a/mcm/tools/handlers.py
+++ b/mcm/tools/handlers.py
@@ -331,6 +331,11 @@ class RequestSubmitter(Handler):
                 "The request is in approval {0}, while submit is required".format(req.get_attribute('approval')), req)
             return False, None
 
+        if req.get_attribute('private'):
+            self.injection_error(
+                "The request {0} is in labeled as private".format(self.prepid), None)
+            return False, None
+
         if req.get_attribute('status') != 'approved':
             self.injection_error(
                 "The request is in status {0}, while approved is required".format(req.get_attribute('status')), req)


### PR DESCRIPTION
request can be labelled private.
the gen contact can have the task submitted using an external script (to be put in the central space).
the gen contact can then register the task name to McM using /restapi/requests/registertask/<prepid>/<task name>.
stats should be updating the document accordingly (updating scripts in the making).
the gen contact can have the request inspect if not happy with the automatic inspect cycle (4h).
the inspection to toggle done follows an expected dataset naming /<dsn>/<campaign>-<tier>-<some process string>...
