### PR TITLE
Enable chain testing within a tree of chains

### DIFF
--- a/mcm/json_layer/chained_request.py
+++ b/mcm/json_layer/chained_request.py
@@ -673,10 +673,12 @@ class chained_request(json_base):
             req_ids = self.get_attribute('chain')
         else:
             req_ids = self.get_attribute('chain')[ self.get_attribute('step'):]
+
         rdb = database('requests')
         setup_file = ''
         for (index,req_id) in enumerate(req_ids):
             req = request(rdb.get(req_id))
+            if req.get_attribute('status') in ['submitted','done']: continue
             ev = events
             if not ev and index!=0 and not req.is_root:
                 ev = -1


### PR DESCRIPTION
added checks and fail-safe for validating a chain that has part already validated, in the case of tree of chains.
the current chain testing would fail to do:
A->B->C1 = chain1
        ->C2 = chain2

when chain1 (ABC1) is being tested, and one wants also (ABC2) to get tested. the proposed changes are meant to remove the interference on A and B from the two tests.

 The ultimate implementation could probably be to have the "tree testing", as for submission of tree of requests in TaskChain.
