### PR TITLE
Concurrent chain valid

### DIFF
--- a/mcm/rest_api/ChainedRequestActions.py
+++ b/mcm/rest_api/ChainedRequestActions.py
@@ -548,6 +548,7 @@ class TestChainedRequest(RESTResource):
                     getattr(mcm_r,'ok_to_move_to_approval_%s'% next)(for_chain=True)
                     mcm_r.update_history({'action': 'approve', 'step':next})
                     mcm_r.set_attribute('approval',next)
+                    mcm_r.reload()
                 else:
                     pass
                     ## fail this for the moment. there is no way to handle this yet
@@ -561,7 +562,7 @@ class TestChainedRequest(RESTResource):
                                                                        mcm_cr.get_attribute('prepid'),
                                                                        mcm_r.get_attribute('prepid')),
                              text, accumulate=True)
-                mcm_r.reload()
+
             except Exception as e:
                 runtest.reset_all( str(e) , notify_one = rid )
                 return dumps({"results" : False, "message" : str(e),"prepid" : args[0]})

--- a/mcm/tools/handlers.py
+++ b/mcm/tools/handlers.py
@@ -313,15 +313,16 @@ class RunChainValid(Handler):
             if success:
                 for (i_r,mcm_r) in enumerate(mcm_rs):
                     mcm_current = request( rdb.get(mcm_r.get_attribute('prepid')))
-                    if mcm_current.json()['_rev'] == mcm_r.json()['_rev']:
-                        if mcm_current.get_attribute('status') != 'new': continue ## should not toggle to the next status for things that are not 'new'
-                        mcm_r.set_status(with_notification=True)
-                        if not mcm_r.reload():
-                            self.reset_all( 'The request %s could not be saved after the runtest procedure' % (mcm_r.get_attribute('prepid')))
-                            return
-                    else:
-                        self.reset_all( 'The request %s has changed during the run test procedure'%(mcm_r.get_attribute('prepid')), notify_one = mcm_r.get_attribute('prepid'))
-                        return        
+                    #if mcm_current.json()['_rev'] == mcm_r.json()['_rev']:
+                    if mcm_current.get_attribute('status') != 'new': 
+                        continue ## should not toggle to the next status for things that are not 'new'
+                    mcm_current.set_status(with_notification=True)
+                    if not mcm_current.reload():
+                        self.reset_all( 'The request %s could not be saved after the runtest procedure' % (mcm_current.get_attribute('prepid')))
+                        return
+                    #else:
+                    #    self.reset_all( 'The request %s has changed during the run test procedure'%(mcm_r.get_attribute('prepid')), notify_one = mcm_r.get_attribute('prepid'))
+                    #    return        
             else:
                 self.reset_all( trace , notify_one = last_fail.get_attribute('prepid') )
                 return


### PR DESCRIPTION
In case two chains are being validated at the same time, with common requests, towards submitting trees of requests (which actually already functions just fine)
