### PR TITLE
Check on a campaign name with characters reshuffled

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1641,11 +1641,13 @@ done
                                 (_, dsn, proc, tier) = ds.split('/')
                                 for goodds in collected:
                                     (_, gdsn, gproc, gtier) = goodds.split('/')
-                                    if dsn != gdsn or not set(
-                                        gproc.split("-")).issubset(proc.split("-")):
-
+                                    if dsn != gdsn:
+                                        goodone = False
+                                    if  not set(gproc.split("-")[1:]).issubset(proc.split("-")[1:]) :
                                         goodone = False #due to #724 we check if expected
                                                         #process_string is subset of generated ones
+                                    if set(gproc.split("-")[0])!=set(proc.split("-")[0]):
+                                        goodone = False #when the campaign name has been suffled for acq era
                         if goodone:
                             ## reduce to what was expected of it
                             those = filter(lambda dn : dn.split('/')[-1] in tiers_expected, those)


### PR DESCRIPTION
because of the check on the full expected dataset name and the modification 2019GEMUpg14DR (mcm campaign) -> GEM2019Upg14DR (ops acquisition era) in assignment by ops, no request of 2019GEMUpg14DR can close anymore, unless merging this changes.

https://hypernews.cern.ch/HyperNews/CMS/get/dataopsrequests/6495.html

