### PR TITLE
skip workflows that only created a DQMIO

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1634,6 +1634,7 @@ done
                     tiers_expected = self.get_tiers()
                     for wma in reversed(self.get_attribute('reqmgr_name')):
                         if not 'pdmv_dataset_list' in wma['content']: continue
+                        if 'DQMIO' in wma['content']['pdmv_dataset_name']: continue ## do not collect from this workflow
                         those = wma['content']['pdmv_dataset_list']
                         goodone = True
                         if len(collected):
@@ -1658,6 +1659,7 @@ done
                                 'message' : 'No output dataset have been recognized'})
                         saved = db.save(self.json())
                         return not_good
+
                     ds_for_accounting = collected[0]
                     if (not 'pdmv_dataset_statuses' in wma_r_N['content'] or
                             not ds_for_accounting in wma_r_N['content']['pdmv_dataset_statuses']):


### PR DESCRIPTION
To continue on the workaround for slipping workflows with DQMIO dataset only.

https://hypernews.cern.ch/HyperNews/CMS/get/dataopsrequests/6495.html