### PR TITLE
Fixing error in GEN validation

### DIFF
--- a/mcm/ValidationControl.py
+++ b/mcm/ValidationControl.py
@@ -618,6 +618,8 @@ class ValidationHandler:
                 what='Validation',
                 message='Validation was successful for %s. Request:\n%s' % (mcm_request.get_attribute('prepid'), mcm_request.textified()))
 
+        self.get_attribute('validation')['dqm'] = 'RelVal' + self.get_attribute('dataset_name')
+
         self.logger.info('Validation job for prepid %s SUCCESSFUL!!!' % prepid)
 
     def process_finished_request_failed(self, prepid, job_out, error_out, was_exited=True, job_error_out='', out_path='', log_out=''):

--- a/mcm/ValidationControl.py
+++ b/mcm/ValidationControl.py
@@ -605,6 +605,8 @@ class ValidationHandler:
         mcm_request.set_status(with_notification=True)
         aux_validation = mcm_request.get_attribute(self.DOC_VALIDATION)
         mcm_request.set_attribute(self.DOC_VALIDATION, doc_validation)
+        mcm_request['validation']['dqm'] = 'RelVal' + mcm_request['dataset_name']
+
         saved = self.request_db.update(mcm_request.json())
         if not saved:
             mcm_request.set_attribute(self.DOC_VALIDATION, aux_validation)
@@ -617,8 +619,6 @@ class ValidationHandler:
         mcm_request.test_success(
                 what='Validation',
                 message='Validation was successful for %s. Request:\n%s' % (mcm_request.get_attribute('prepid'), mcm_request.textified()))
-
-        self.get_attribute('validation')['dqm'] = 'RelVal' + self.get_attribute('dataset_name')
 
         self.logger.info('Validation job for prepid %s SUCCESSFUL!!!' % prepid)
 

--- a/mcm/ValidationControl.py
+++ b/mcm/ValidationControl.py
@@ -605,7 +605,7 @@ class ValidationHandler:
         mcm_request.set_status(with_notification=True)
         aux_validation = mcm_request.get_attribute(self.DOC_VALIDATION)
         mcm_request.set_attribute(self.DOC_VALIDATION, doc_validation)
-        mcm_request['validation']['dqm'] = 'RelVal' + mcm_request['dataset_name']
+        mcm_request.get_attribute('validation')['dqm'] = 'RelVal' + mcm_request.get_attribute('dataset_name')
 
         saved = self.request_db.update(mcm_request.json())
         if not saved:

--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1391,16 +1391,19 @@ class request(json_base):
 
                 #for GEN validation, one needs to modify the datatier
                 new_datatier = cmsd.split('--datatier ')[1].split()[0]
+                old_datatier = new_datatier
                 new_datatier += dqm_datatier 
                 res = res.replace('--datatier %s' % (old_datatier), '--datatier %s' % (new_datatier))
 
                 #for GEN validation, one needs to modify the eventcontent
                 new_eventcontent = cmsd.split('--eventcontent ')[1].split()[0]
+                old_eventcontent = new_eventcontent
                 new_eventcontent += dqm_eventcontent 
                 res = res.replace('--eventcontent %s' % (old_eventcontent), '--eventcontent %s' % (new_eventcontent))
                 
                 #for GEN validation, one needs to modify steps
                 new_step = cmsd.split('--step ')[1].split()[0]
+                old_step = new_step
                 new_step += dqm_step 
                 res = res.replace('--step %s' % (old_step), '--step %s' % (new_step))
 
@@ -1497,15 +1500,16 @@ class request(json_base):
 
         if for_validation:
                
-               infile += 'cmsDriver step3 --python_file harvest.py --no_exec --conditions %s --filein file: %s -s HARVESTING:genHarvesting --harvesting AtRunEnd --filetype DQM --mc -n -1\n' % (self.get_attribute('sequences')[sequence_index]["conditions"], output_file)
-               infile += 'cmsRun harvest.py\n'
-
-               #Example: RelValDYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8__CMSSW_10_6_5-106X_mc2017_realistic_v6-v1__DQMIO.root
-               filename_dqm = 'DQM_V0001_R000000001__RelVal%s__%s-%s__DQMIO.root' % (self.get_attribute('dataset_name'), self.get_attribute('cmssw_release'), self.get_attribute('sequences')[sequence_index]["conditions"])
-               infile += 'mv DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root %s\n' % (filename_dqm)
-               infile += 'source /afs/cern.ch/cms/PPD/PdmV/tools/subSetupAuto.sh \n'
-               infile += 'wget https://raw.githubusercontent.com/rovere/dqmgui/index128/bin/visDQMUpload\n'
-               infile += 'python visDQMUpload https://cmsweb-testbed.cern.ch/dqm/relval/ %s\n' % (filename_dqm) 
+            output_file = '%s_inDQM.root ' % (self.get_attribute('prepid'))
+            infile += 'cmsDriver step3 --python_file harvest.py --no_exec --conditions %s --filein file: %s -s HARVESTING:genHarvesting --harvesting AtRunEnd --filetype DQM --mc -n -1\n' % (self.get_attribute('sequences')[0]["conditions"], output_file)
+            infile += 'cmsRun harvest.py\n'
+            
+            #Example: RelValDYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8__CMSSW_10_6_5-106X_mc2017_realistic_v6-v1__DQMIO.root
+            filename_dqm = 'DQM_V0001_R000000001__RelVal%s__%s-%s__DQMIO.root' % (self.get_attribute('dataset_name'), self.get_attribute('cmssw_release'), self.get_attribute('sequences')[0]["conditions"])
+            infile += 'mv DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root %s\n' % (filename_dqm)
+            infile += 'source /afs/cern.ch/cms/PPD/PdmV/tools/subSetupAuto.sh \n'
+            infile += 'wget https://raw.githubusercontent.com/rovere/dqmgui/index128/bin/visDQMUpload\n'
+            infile += 'python visDQMUpload https://cmsweb-testbed.cern.ch/dqm/relval/ %s\n' % (filename_dqm) 
         
         # if there was a release setup, jsut remove it
         # not in dev

--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1384,7 +1384,6 @@ class request(json_base):
                 res += '--customise Configuration/DataProcessing/Utils.addMonitoring '
 
             if self.get_attribute('validation').get('valid', False):
-                self.set_attribute('validation'['dqm'], 'RelVal' + self.get_attribute('dataset_name'))
                 dqm_datatier = ',DQMIO'
                 dqm_step = ',DQM' 
                 dqm_eventcontent = ',VALIDATION:genvalid_' + self.get_attribute('validation').get('content', 'all').lower()
@@ -1498,7 +1497,7 @@ class request(json_base):
         # no need for directory traversal (parent stays unaffected)
 
 
-        if for_validation:
+        if for_validation and self.get_attribute('validation').get('valid', False):
                
             output_file = '%s_inDQM.root ' % (self.get_attribute('prepid'))
             infile += 'cmsDriver step3 --python_file harvest.py --no_exec --conditions %s --filein file: %s -s HARVESTING:genHarvesting --harvesting AtRunEnd --filetype DQM --mc -n -1\n' % (self.get_attribute('sequences')[0]["conditions"], output_file)
@@ -1511,6 +1510,8 @@ class request(json_base):
             infile += 'wget https://raw.githubusercontent.com/rovere/dqmgui/index128/bin/visDQMUpload\n'
             infile += 'python visDQMUpload https://cmsweb-testbed.cern.ch/dqm/relval/ %s\n' % (filename_dqm) 
         
+            self.set_attribute('validation'["dqm"], 'RelVal' + self.get_attribute('dataset_name'))
+
         # if there was a release setup, jsut remove it
         # not in dev
         if (directory or for_validation) and not l_type.isDev():

--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1496,7 +1496,6 @@ class request(json_base):
         # since it's all in a subshell, there is
         # no need for directory traversal (parent stays unaffected)
 
-
         if for_validation and self.get_attribute('validation').get('valid', False):
                
             output_file = '%s_inDQM.root ' % (self.get_attribute('prepid'))
@@ -1510,8 +1509,6 @@ class request(json_base):
             infile += 'wget https://raw.githubusercontent.com/rovere/dqmgui/index128/bin/visDQMUpload\n'
             infile += 'python visDQMUpload https://cmsweb-testbed.cern.ch/dqm/relval/ %s\n' % (filename_dqm) 
         
-            self.set_attribute('validation'["dqm"], 'RelVal' + self.get_attribute('dataset_name'))
-
         # if there was a release setup, jsut remove it
         # not in dev
         if (directory or for_validation) and not l_type.isDev():


### PR DESCRIPTION
Should fix this error happening when running validation from McM:

Unexpected exception while trying to submit HIG-RunIISummer19UL17wmLHEGEN-00182 message: string indices must be integers, not str
traceback Traceback (most recent call last):
 File "/home/mcm/cmsPdmV/mcm/ValidationControl.py", line 342, in submit_jobs
   result_dict = self.submit_request(prepid, test_path)
 File "/home/mcm/cmsPdmV/mcm/ValidationControl.py", line 236, in submit_request
   to_write = mcm_request.get_setup_file(run=True, do_valid=True, for_validation=True, gen_script=True)
 File "/home/mcm/cmsPdmV/mcm/json_layer/request.py", line 1387, in get_setup_file
   self.set_attribute('validation'['dqm'], 'RelVal' + self.get_attribute('dataset_name'))
TypeError: string indices must be integers, not str
