### PR TITLE
[PDMVDEV-32] Change SMTP server

### DIFF
--- a/mcm/tools/communicator.py
+++ b/mcm/tools/communicator.py
@@ -41,7 +41,7 @@ class communicator:
                 # self.logger.info('Sending a message from cache \n%s'% (text))
                 try:
                     msg.attach(MIMEText(text))
-                    smtpObj = smtplib.SMTP()
+                    smtpObj = smtplib.SMTP(host="cernmx.cern.ch", port=25)
                     smtpObj.connect()
                     smtpObj.sendmail(sender, destination, msg.as_string())
                     smtpObj.quit()


### PR DESCRIPTION
Current SMTP server, smtp.cern.ch, is going to be decomissioned on June 30, 2023 Use the new server for sending emails from applications