### PR TITLE
Tickets, requests and singularity

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1685,13 +1685,13 @@ class request(json_base):
                               '# Mount afs, eos, cvmfs',
                               '# Mount /etc/grid-security for xrootd',
                               'export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"',
-                              'singularity run -B /afs -B /eos -B /cvmfs -B /etc/grid-security --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)]
+                              'singularity run -B /afs -B /eos -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)]
             else:
                 # Config generation for production run on CC7 machine - vocms0481
                 # If it's CC7, just run the script normally
                 # If it's not CC7, run it in singularity container
                 bash_file += ['export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"',
-                              'singularity run -B /afs -B /cvmfs -B /etc/grid-security --no-home /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)]
+                              'singularity run -B /afs -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --no-home /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)]
 
         # Empty line at the end of the file
         bash_file += ['']

--- a/mcm/main.py
+++ b/mcm/main.py
@@ -1,6 +1,6 @@
 from rest_api.ControlActions import Search, Communicate, CacheInfo, CacheClear
 from rest_api.RestAPIMethod import RESTResourceIndex, RESTResource
-from rest_api.RequestActions import ImportRequest, ManageRequest, DeleteRequest, GetRequest, GetRequestByDataset, UpdateRequest, GetCmsDriverForRequest, GetFragmentForRequest, GetSetupForRequest, ApproveRequest, ResetRequestApproval, SetStatus, GetStatus, GetStatusAndApproval, GetEditable, GetDefaultGenParams, CloneRequest, RegisterUser, GetActors, NotifyUser, InspectStatus, UpdateStats, RequestsFromFile, StalledReminder, RequestsReminder, SearchableRequest, UpdateMany, ListRequestPrepids, OptionResetForRequest, GetRequestOutput, GetInjectCommand, GetUploadCommand, GetUniqueValues, PutToForceComplete, ForceCompleteMethods, Reserve_and_ApproveChain, TaskChainRequestDict, RequestsPriorityChange, UpdateEventsFromWorkflow, PPDTags, GENLogOutput
+from rest_api.RequestActions import ImportRequest, ManageRequest, DeleteRequest, GetRequest, GetRequestByDataset, UpdateRequest, GetCmsDriverForRequest, GetFragmentForRequest, GetSetupForRequest, ApproveRequest, ResetRequestApproval, SetStatus, GetStatus, GetStatusAndApproval, GetEditable, GetDefaultGenParams, CloneRequest, RegisterUser, GetActors, NotifyUser, InspectStatus, UpdateStats, RequestsFromFile, StalledReminder, RequestsReminder, SearchableRequest, UpdateMany, ListRequestPrepids, OptionResetForRequest, GetRequestOutput, GetInjectCommand, GetUploadCommand, GetUniqueValues, PutToForceComplete, ForceCompleteMethods, Reserve_and_ApproveChain, TaskChainRequestDict, RequestsPriorityChange, UpdateEventsFromWorkflow, PPDTags, GENLogOutput, RequestsFromDataset
 from rest_api.CampaignActions import CreateCampaign, DeleteCampaign, UpdateCampaign, GetCampaign, ToggleCampaignStatus, GetCmsDriverForCampaign, InspectCampaigns
 from rest_api.ChainedCampaignActions import CreateChainedCampaign, DeleteChainedCampaign, GetChainedCampaign, UpdateChainedCampaign
 from rest_api.ChainedRequestActions import ForceChainReqToDone, ForceStatusDoneToProcessing, CreateChainedRequest, ChainsFromTicket, ChainedRequestsPriorityChange, UpdateChainedRequest, DeleteChainedRequest, GetChainedRequest,  FlowToNextStep, ApproveChainedRequest, InspectChain, RewindToPreviousStep, RewindToRoot, SearchableChainedRequest, TestChainedRequest, GetSetupForChains, TaskChainDict, InjectChainedRequest, SoftResetChainedRequest, ToForceFlowList, RemoveFromForceFlowList, GetUniqueChainedRequestValues
@@ -207,6 +207,7 @@ api.add_resource(
     '/restapi/requests/get/<string:request_id>',
     '/public/restapi/requests/get/<string:request_id>')
 api.add_resource(GetCmsDriverForRequest, '/restapi/requests/get_cmsDrivers/<string:request_id>')
+api.add_resource(RequestsFromDataset, '/public/restapi/requests/from_dataset_name/<string:dataset_name>')
 api.add_resource(
     ApproveRequest,
     '/restapi/requests/approve',

--- a/mcm/scripts/edit_controller.js
+++ b/mcm/scripts/edit_controller.js
@@ -536,7 +536,7 @@ testApp.directive("customMccmChains", function($http, $rootScope){
           return [];
         }
         const campaign = $rootScope.campaignsForChains.length ? '&prepid___=' + $rootScope.campaignsForChains.join(',') : '';
-        const url = "search/?db_name=chained_campaigns&include_fields=prepid&valid=true&prepid=" + viewValue + "*" + campaign;
+        const url = "search/?db_name=chained_campaigns&include_fields=prepid&valid=true&limit=100&prepid=" + viewValue + "*" + campaign;
         if (scope.suggestionCache[url]) {
           const suggestions = scope.suggestionCache[url];
           scope.newestSuggestions = suggestions.filter(x => scope.chainedCampaigns.indexOf(x) < 0);

--- a/mcm/tools/communicator.py
+++ b/mcm/tools/communicator.py
@@ -41,7 +41,7 @@ class communicator:
                 # self.logger.info('Sending a message from cache \n%s'% (text))
                 try:
                     msg.attach(MIMEText(text))
-                    smtpObj = smtplib.SMTP(host="cernmx.cern.ch", port=25)
+                    smtpObj = smtplib.SMTP()
                     smtpObj.connect()
                     smtpObj.sendmail(sender, destination, msg.as_string())
                     smtpObj.quit()

--- a/mcm/tools/communicator.py
+++ b/mcm/tools/communicator.py
@@ -41,7 +41,7 @@ class communicator:
                 # self.logger.info('Sending a message from cache \n%s'% (text))
                 try:
                     msg.attach(MIMEText(text))
-                    smtpObj = smtplib.SMTP()
+                    smtpObj = smtplib.SMTP(host="cernmx.cern.ch", port=25)
                     smtpObj.connect()
                     smtpObj.sendmail(sender, destination, msg.as_string())
                     smtpObj.quit()

--- a/mcm/tools/communicator.py
+++ b/mcm/tools/communicator.py
@@ -114,7 +114,7 @@ class communicator:
 
         try:
             msg.attach(MIMEText(text))
-            smtpObj = smtplib.SMTP(host="cernmx.cern.ch", port=25)
+            smtpObj = smtplib.SMTP()
             smtpObj.connect()
             communicator.logger.info('Sending %s to %s...' % (msg['Subject'], msg['To']))
             smtpObj.sendmail(sender, destination, msg.as_string())

--- a/mcm/tools/communicator.py
+++ b/mcm/tools/communicator.py
@@ -114,7 +114,7 @@ class communicator:
 
         try:
             msg.attach(MIMEText(text))
-            smtpObj = smtplib.SMTP()
+            smtpObj = smtplib.SMTP(host="cernmx.cern.ch", port=25)
             smtpObj.connect()
             communicator.logger.info('Sending %s to %s...' % (msg['Subject'], msg['To']))
             smtpObj.sendmail(sender, destination, msg.as_string())

--- a/mcm/tools/handlers.py
+++ b/mcm/tools/handlers.py
@@ -341,7 +341,7 @@ class SubmissionsBase(Handler):
             command += '  exit 1\n'
             command += 'fi\n'
             command += 'export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"\n'
-            command += 'singularity run -B /afs -B /cvmfs --no-home /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME %s\n' % (executable_file_name)
+            command += 'singularity run -B /afs -B /cvmfs -B /etc/pki/ca-trust --no-home /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME %s\n' % (executable_file_name)
             command += 'rm -f %s\n' % (executable_file_name)
 
         command += 'rm -f %s' % (proxy_file_name)


### PR DESCRIPTION
1. Load up to 100 chain campaigns when a ticket is created
2. Update singularity execution to load CA certificates from an auxiliary location. This update was applied in April 2023 after the CERN CA certificates issue.
3. Retrieve requests by the `dataset_name` attribute, this is related to #1100 