### PR TITLE
Delete multiple requests at the same time

### DIFF
--- a/mcm/HTML/requests.html
+++ b/mcm/HTML/requests.html
@@ -476,6 +476,9 @@
           <a ng-click="actionPrompt('reset', 'selected')" rel="tooltip" ng-hide="role(1);" title="Reset selected requests" ng-href="#">
             <i class="icon-repeat"></i>
           </a>
+          <a ng-click="deleteMultipleRequestPrompt('selected')" rel="tooltip" ng-hide="role(1);" title="Delete selected requests" ng-href="#">
+            <i class="icon-minus-sign"></i>
+          </a>
           <a ng-click="actionPrompt('option_reset', 'selected')" rel="tooltip" ng-hide="role(1);"  title="Option Reset selected requests" ng-href="#">
             <i class="icon-share"></i>
           </a>


### PR DESCRIPTION
At the bottom panel located in the request view (‘Multiple selection buttons’), this includes a new button to delete all the requests already selected. In case of error, display a panel describing the issue. This button is only shown if the user has the role `generator_contact` or higher.