### PR TITLE
Allow `generator contacts` to update the `dataset_name` attribute

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -215,11 +215,15 @@ class request(json_base):
                 # Allow generator conveners to edit dataset name for
                 # "validation-validation", "define-" and "approve-" requests
                 editable['dataset_name'] = True
+                editable['extension'] = True
+                editable['process_string'] = True
 
             if self.current_user_level == 1 and self.get_attribute('approval') in ('validation', 'define', 'approve'):
                 # Allow generator contacts to edit dataset name for
                 # "validation-validation", "define-" and "approve-" requests
                 editable['dataset_name'] = True
+                editable['extension'] = True
+                editable['process_string'] = True
 
             if self.current_user_level > 3:  # only for admins
                 for key in self._json_base__schema:

--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -216,6 +216,11 @@ class request(json_base):
                 # "validation-validation", "define-" and "approve-" requests
                 editable['dataset_name'] = True
 
+            if self.current_user_level == 1 and self.get_attribute('approval') in ('validation', 'define', 'approve'):
+                # Allow generator contacts to edit dataset name for
+                # "validation-validation", "define-" and "approve-" requests
+                editable['dataset_name'] = True
+
             if self.current_user_level > 3:  # only for admins
                 for key in self._json_base__schema:
                     editable[key] = True


### PR DESCRIPTION
Solves: #1116

1. Allow the described role to modify the dataset name after the validation step.