### PR TITLE
Remove cross sections from the UI

### DIFF
--- a/mcm/scripts/edit.js
+++ b/mcm/scripts/edit.js
@@ -118,7 +118,6 @@ angular.module('testApp').controller('ModalDemoCtrl',
 
     // Generator parameters stuff
     $scope.showData = {
-        "Cross section": "cross_section",
         "Filter efficiency": "filter_efficiency",
         "Filter efficiency error": "filter_efficiency_error",
         "Match efficiency": "match_efficiency",
@@ -475,7 +474,6 @@ testApp.directive("generatorParams", function($http){
     '          <label class="control-label">{{key}}</label>'+
     '          <div class="controls">'+
     '            <input type="text" ng-model="gen_params.data[value]">'+
-    '            <a ng-if="key==\'Cross section\'" class="label label-info" rel="tooltip" title="pico barn" ng-href="#">pb</a>'+
     '          </div>'+
     '        </div>'+
     '      </form>'+
@@ -490,7 +488,6 @@ testApp.directive("generatorParams", function($http){
     '      <dl class="dl-horizontal" style="margin-bottom: 0px; margin-top: 0px;" ng-if="$index==genParam_data.length-1">'+
     '        <dt ng-repeat-start="(key, value) in showData">{{key.toLowerCase()}}</dt>'+
     '        <dd ng-repeat-end class="clearfix">{{elem[value]}}'+
-    '          <a ng-if="key==\'Cross section\'" class="label label-info" rel="tooltip" title="pico barn" ng-href="#">pb</a>'+
     '        </dd>'+
     '        <dt>author username</dt>'+
     '        <dd class="clearfix">{{elem["submission_details"]["author_username"]}}</dd>'+

--- a/mcm/scripts/requests_ctrl.js
+++ b/mcm/scripts/requests_ctrl.js
@@ -293,10 +293,6 @@ testApp.directive("generatorParams", function ($http) {
       '        <dl class="dl-horizontal" style="margin-bottom: 0px; margin-top: 0px;">' +
       '          <dt>{{"version"}}</dt>' +
       '          <dd class="clearfix">{{param["version"]}}</dd>' +
-      '          <dt>{{"cross section"}}</dt>' +
-      '          <dd class="clearfix">{{param["cross_section"]}}' +
-      '          <a class="label label-info" rel="tooltip" title="pico barn" ng-href="#">pb</a>' +
-      '          </dd>' +
       '          <dt>{{"filter efficiency"}}</dt>' +
       '          <dd class="clearfix">{{param["filter_efficiency"]}}</dd>' +
       '          <dt>{{"filter efficiency error"}}</dt>' +
@@ -314,10 +310,6 @@ testApp.directive("generatorParams", function ($http) {
       '      <dl class="dl-horizontal" style="margin-bottom: 0px; margin-top: 0px;">' +
       '        <dt>{{"version"}}</dt>' +
       '        <dd class="clearfix">{{param["version"]}}</dd>' +
-      '        <dt>{{"cross section"}}</dt>' +
-      '        <dd class="clearfix">{{param["cross_section"]}}' +
-      '          <a class="label label-info" rel="tooltip" title="pico barn" ng-href="#">pb</a>' +
-      '        </dd>' +
       '        <dt>{{"filter efficiency"}}</dt>' +
       '        <dd class="clearfix">{{param["filter_efficiency"]}}</dd>' +
       '        <dt>{{"filter efficiency error"}}</dt>' +


### PR DESCRIPTION
The cross sections shown in the McM UI were confusing users into thinking that they were correct, which is almost  never the case. Remove them from the UI (but keep them in the database for now).

@ggonzr could you deploy this to the dev machine for testing?