### PR TITLE
Remove `cross` option for generator parameters

### DIFF
--- a/mcm/json_layer/generator_parameters.py
+++ b/mcm/json_layer/generator_parameters.py
@@ -28,7 +28,7 @@ class generator_parameters(json_base):
 
     def isInValid(self):
         for (k,v) in self._json_base__json.items():
-            if len(k)>=4 and k[0:5] in ['cross','filte','match'] and v<0:
+            if len(k)>=4 and k[0:5] in ['filte','match'] and v<0:
                 return True
             if 'efficiency' in k and v>1.:
                 return True


### PR DESCRIPTION
Related topic: https://cms-talk.web.cern.ch/t/problem-with-adding-cross-section-to-mcm-requests/36272/3