### PR TITLE
Improve error message when force-completing a request with no output

### DIFF
--- a/mcm/rest_api/RequestActions.py
+++ b/mcm/rest_api/RequestActions.py
@@ -1613,11 +1613,22 @@ class PutToForceComplete(RESTResource):
                 ",".join(curr_user.get_pwgs()), req.get_attribute("pwg"))
 
             return {"prepid": pid, "results": False, 'message': message}
-        # check if request if at least 50% complete
-        if req.get_attribute("completed_events") < req.get_attribute("total_events") * 0.5 and curr_user.get_attribute('role') != 'administrator':
-            self.logger.info('%s is below 50percent completion' % (pid))
-            message = 'Request is below 50 percent completion'
-            return {"prepid": pid, "results": False, 'message': message}
+
+        # Non-administrators can only force-complete requests with at least half
+        # the requested statistics produced.
+        if curr_user.get_attribute('role') != 'administrator':
+            # Check that the request keeps at least one output, otherwise it's
+            # always either 0% or 100% complete. See #1114.
+            if not any(req.get_attribute("keep_output")):
+                self.logger.info('%s has no output', pid)
+                message = 'Request keeps no output, try another request in the chain'
+                return {"prepid": pid, "results": False, 'message': message}
+
+            # Check if request if at least 50% complete
+            if req.get_attribute("completed_events") < req.get_attribute("total_events") * 0.5:
+                self.logger.info('%s is below 50 percent completion', pid)
+                message = 'Request is below 50 percent completion'
+                return {"prepid": pid, "results": False, 'message': message}
 
         if pid in forcecomplete_list['value']:
             self.logger.info('%s already in forcecompletion' % (pid))


### PR DESCRIPTION
Requests without output are always considered either 0% or 100% complete by ReqMgr, there is no middle ground. For non-admins, force-completing a request is only possible if it is more than 50% complete. So if the request has no output, it can only be force-completed by a non-admin if it is already complete.

What the non-admins should do is trigger the force-completion of a request in the same (computing) workflow that does keep its output. Force-completion acts at the workflow level, and Unified is smart enough to mark all requests in the workflow as complete (100% completion for those not keeping output).

To help confused users trying to force-complete requests without output, add an error message telling them why it doesn't work and what they could do about it (try some other request in the chain). Hopefully if the user is smart enough they understand which requests in the chain will work.

Use the opportunity to marginally improve the coding style and fix a typo.

See #1114.