### PR TITLE
Include the new McM REST client

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1344,7 +1344,14 @@ class request(json_base):
         prepid = self.get_attribute('prepid')
         member_of_campaign = self.get_attribute('member_of_campaign')
         scram_arch = self.get_scram_arch().lower()
-        bash_file = ['#!/bin/bash', '']
+        bash_file = [
+            '#!/bin/bash', 
+            '',
+            '# Binds for singularity containers',
+            '# Mount /afs, /eos, /cvmfs, /etc/grid-security for xrootd',
+            "export APPTAINER_BINDPATH='/afs,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/eos,/etc/pki/ca-trust,/run/user,/var/run/user'",
+            '',
+        ]
 
         if not for_validation or automatic_validation:
             bash_file += ['#############################################################',
@@ -1442,10 +1449,6 @@ class request(json_base):
             ]
             bash_file += [
                 '# Run in singularity container',
-                '# Mount afs, eos, cvmfs',
-                '# Mount /etc/grid-security for xrootd',
-                # Note the following line is also appended to the singularity run command
-                'APPTAINER_BINDPATH=/afs,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/eos,/etc/pki/ca-trust,/run/user,/var/run/user; '
                 'singularity run --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/%s $(echo $(pwd)/%s)' % (cms_gen_os, cms_gen_file),
                 '',
             ]
@@ -1745,15 +1748,13 @@ class request(json_base):
             # Validation will run on CMS CAF nodes (HTCondor, lxplus)
             bash_file += [
                 '# Run in singularity container',
-                '# Mount afs, eos, cvmfs',
-                '# Mount /etc/grid-security for xrootd',
                 'export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"',
-                'singularity run -B /afs -B /eos -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)
+                'singularity run --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)
             ]
         else:
             bash_file += [
                 'export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"',
-                'singularity run -B /afs -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --no-home /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)
+                'singularity run --no-home /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)
             ]
 
         # Empty line at the end of the file

--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1406,23 +1406,14 @@ class request(json_base):
             bash_file += ['# GEN Script begin',
                           'rm -f request_fragment_check.py',
                           'wget -q https://raw.githubusercontent.com/cms-sw/genproductions/master/bin/utils/request_fragment_check.py',
-                          'chmod +x request_fragment_check.py']
+                          'chmod +x request_fragment_check.py',
+                          '',]
             
-            # Temporal: Remove instructions that source the old version
-            # of the McM REST client
-            bash_file += [
-                '',
-                '# Remove all instructions that import remote modules',
-                "sed -i '/sys.path.append(/d' request_fragment_check.py",
-                '',
-            ]
-
             # Checking script invocation
             request_fragment_check = './request_fragment_check.py --bypass_status --prepid %s' % (prepid)
             if is_dev:
                 # Add --dev, so script would use McM DEV
                 request_fragment_check += ' --dev'
-                request_fragment_check += ' --develop' # Also, remove the internal "check" mechanism
 
             if automatic_validation:
                 # For automatic validation
@@ -1453,7 +1444,9 @@ class request(json_base):
                 '# Run in singularity container',
                 '# Mount afs, eos, cvmfs',
                 '# Mount /etc/grid-security for xrootd',
-                'singularity run -B /afs -B /eos -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/%s $(echo $(pwd)/%s)' % (cms_gen_os, cms_gen_file),
+                # Note the following line is also appended to the singularity run command
+                'APPTAINER_BINDPATH=/afs,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/eos,/etc/pki/ca-trust,/run/user,/var/run/user; '
+                'singularity run --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/%s $(echo $(pwd)/%s)' % (cms_gen_os, cms_gen_file),
                 '',
             ]
 


### PR DESCRIPTION
Related to: [#23](https://github.com/cms-PdmV/mcm_scripts/issues/23)

Use the new version for the McM REST client and avoid loading the old version from a folder in AFS. In this case, the module is loaded by the embedded script: [request_fragment_check.py](https://github.com/cms-sw/genproductions/blob/45b479075f09cdcb23fcc35c2142d80e360d8c99/bin/utils/request_fragment_check.py#L56-L63) owned by the CMS GEN team. To achieve a smooth integration with the new version, this sets an isolated `venv` where the McM REST client is installed and uses an isolated cms-sw singularity container to perform the execution using AlmaLinux 9 as OS and Python 3.9 as the default version.
