### PR TITLE
Send requests with valid datasets with zero events to status done

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -2285,7 +2285,8 @@ class request(json_base):
                     # in case it keeps any output and produced 0 events
                     # means something is wrong in production
                     if (self.get_attribute('completed_events') <= 0
-                            and self.get_attribute("keep_output").count(True) > 0):
+                            and self.get_attribute("keep_output").count(True) > 0
+                            and not force):
 
                         not_good.update({
                             'message': '%s completed but with no statistics. stats DB lag. saving the request anyway.' % (


### PR DESCRIPTION
Fixes: https://github.com/cms-PdmV/cmsPdmV/issues/1147

Allow to set a status `done` for a request if its output datasets are valid with zero events only if the inspection is forced.