### PR TITLE
Limit infinite requests

### DIFF
--- a/mcm/couchdb_layer/mcm_database.py
+++ b/mcm/couchdb_layer/mcm_database.py
@@ -324,7 +324,7 @@ class database:
 
         # Tell the user when MAX_READ is reached
         if len(data) == self.MAX_READ:
-            raise ValueError('The database returned too much data')
+            raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
 
         data = json.loads(data)
         if options.get('include_docs'):
@@ -497,7 +497,7 @@ class database:
 
             # Tell the user when MAX_READ is reached
             if len(data) == self.MAX_READ:
-                raise ValueError('The database returned too much data')
+                raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
 
             data = json.loads(data)
             if total_rows:

--- a/mcm/couchdb_layer/mcm_database.py
+++ b/mcm/couchdb_layer/mcm_database.py
@@ -195,13 +195,16 @@ class database:
         Non existing documents are changed with None
         Order is preserved
         """
-        request = self.couch_request('%s/_bulk_get' % (self.db_name),
-                                     method='POST',
-                                     data={'docs': [{'id': x} for x in ids]})
-        data = self.opener.open(request)
-        results = json.loads(data.read(self.MAX_READ))['results']
-        results = [r['docs'][-1]['ok'] for r in results if r.get('docs') if r['docs'][-1].get('ok')]
-        return results
+        try:
+            request = self.couch_request('%s/_bulk_get' % (self.db_name),
+                                        method='POST',
+                                        data={'docs': [{'id': x} for x in ids]})
+            data = self.opener.open(request)
+            results = json.loads(data.read(self.MAX_READ))['results']
+            results = [r['docs'][-1]['ok'] for r in results if r.get('docs') if r['docs'][-1].get('ok')]
+            return results
+        except ValueError:
+            return []
 
     def document_exists(self, prepid, include_deleted=False):
         """
@@ -319,26 +322,39 @@ class database:
 
         self.logger.debug('Query view %s', url)
         request = self.couch_request(url)
+        try:
+            data = self.opener.open(request).read(self.MAX_READ)
+            # Tell the user when MAX_READ is reached
+            if len(data) == self.MAX_READ:
+                error_msg = (
+                    'The database returned too much data. '
+                    'Use a better query and pagination to collect a smaller set of results'
+                )
+                self.logger.error(error_msg)
+                if with_total_rows:
+                    return {'rows': [], 'total_rows': 0, 'message': error_msg}
 
-        data = self.opener.open(request).read(self.MAX_READ)
+                return []
 
-        # Tell the user when MAX_READ is reached
-        if len(data) == self.MAX_READ:
-            raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
+            data = json.loads(data)
+            if options.get('include_docs'):
+                rows = [r['doc'] for r in data.get('rows', [])]
+            elif design_doc == 'unique':
+                rows = [r['key'] for r in data.get('rows', [])]
+            else:
+                rows = [r['value'] for r in data.get('rows', [])]
 
-        data = json.loads(data)
-        if options.get('include_docs'):
-            rows = [r['doc'] for r in data.get('rows', [])]
-        elif design_doc == 'unique':
-            rows = [r['key'] for r in data.get('rows', [])]
-        else:
-            rows = [r['value'] for r in data.get('rows', [])]
+            if with_total_rows:
+                total_rows = data.get('total_rows', 0)
+                return {'rows': rows, 'total_rows': total_rows}
 
-        if with_total_rows:
-            total_rows = data.get('total_rows', 0)
-            return {'rows': rows, 'total_rows': total_rows}
+            return rows
+        except Exception as ex:
+            self.logger.error('Error querying view %s: %s', url, ex)
+            if with_total_rows:
+                return {'rows': [], 'total_rows': 0}
 
-        return rows
+            return []
 
     def get_all(self, page=-1, limit=20, with_total_rows=False):
         """
@@ -438,8 +454,6 @@ class database:
         """
         Query couchdb-lucene with given query dict. By default, returns a list of dicts.
         If total_rows is True, returns a dict of results "rows" and number of "total_rows" instead.
-
-        Raises on error.
         """
         limit, skip = self.pagify(page, limit)
         query = self.make_query(query_dict)
@@ -475,36 +489,40 @@ class database:
         for attempt in range(1, self.max_attempts + 1):
             try:
                 data = self.opener.open(lucene_request).read(self.MAX_READ)
+                # Tell the user when MAX_READ is reached
+                if len(data) == self.MAX_READ:
+                    error_msg = (
+                        'The database returned too much data. '
+                        'Use a better query and pagination to collect a smaller set of results'
+                    )
+                    self.logger.error(error_msg)
+                    if total_rows:
+                        return {'rows': [], 'total_rows': 0, 'message': error_msg}
+
+                    return []
+
+                data = json.loads(data)
+                if total_rows:
+                    return {'rows': [r['doc'] for r in data.get('rows', [])],
+                            'total_rows': data.get('total_rows', 0)}
+
+                return [r['doc'] for r in data.get('rows', [])]
+
             except urllib2.HTTPError as http_error:
                 code = http_error.code
                 self.logger.error('HTTP error %s %s: %s', url, options, http_error)
                 if 400 <= code < 500:
                     # If it's HTTP 4xx - bad request, no point in retry
-                    raise
+                    break
 
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
-                else:
-                    raise
             except Exception as ex:
                 self.logger.error('Error %s %s: %s', url, options, ex)
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
-                else:
-                    raise
-
-            # Tell the user when MAX_READ is reached
-            if len(data) == self.MAX_READ:
-                raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
-
-            data = json.loads(data)
-            if total_rows:
-                return {'rows': [r['doc'] for r in data.get('rows', [])],
-                        'total_rows': data.get('total_rows', 0)}
-
-            return [r['doc'] for r in data.get('rows', [])]
 
         if total_rows:
             return {'rows': [],

--- a/mcm/couchdb_layer/mcm_database.py
+++ b/mcm/couchdb_layer/mcm_database.py
@@ -280,7 +280,11 @@ class database:
         """
         if page_num < 0:
             # Page <0 means "all", but it still has to be limited to something
-            return 9999, 0
+            return 1000, 0
+
+        if limit < 0 or limit > 1000:
+            # Always enforce a limit
+            limit = 1000
 
         skip = limit * page_num
         return limit, skip

--- a/mcm/couchdb_layer/mcm_database.py
+++ b/mcm/couchdb_layer/mcm_database.py
@@ -17,6 +17,8 @@ class database:
     # Cache timeout in seconds
     CACHE_TIMEOUT = 60 * 60
     IP_CACHE_TIMEOUT = 15 * 60
+    MAX_READ = int(10e6)  # 10MB should be enough for anyone
+
     cache = SimpleCache()
     ip_cache = SimpleCache()
 
@@ -128,11 +130,11 @@ class database:
         for attempt in range(1, self.max_attempts + 1):
             try:
                 data = self.opener.open(db_request)
-                return json.loads(data.read())
+                return json.loads(data.read(self.MAX_READ))
             except urllib2.HTTPError as http_error:
                 code = http_error.code
                 if code == 404 and include_deleted:
-                    data = http_error.read()
+                    data = http_error.read(self.MAX_READ)
                     # Database returned 404 - not found
                     # Document might have never existed or it could be deleted
                     data_json = json.loads(data)
@@ -197,7 +199,7 @@ class database:
                                      method='POST',
                                      data={'docs': [{'id': x} for x in ids]})
         data = self.opener.open(request)
-        results = json.loads(data.read())['results']
+        results = json.loads(data.read(self.MAX_READ))['results']
         results = [r['docs'][-1]['ok'] for r in results if r.get('docs') if r['docs'][-1].get('ok')]
         return results
 
@@ -261,7 +263,7 @@ class database:
         self.logger.info('Saving "%s" (%s) in "%s"...', doc_id, doc_rev, self.db_name)
         request = self.couch_request(self.db_name, 'POST', data=doc)
         try:
-            data = self.opener.open(request).read()
+            data = self.opener.open(request).read(self.MAX_READ)
             data = json.loads(data)
             success = data.get('ok') is True
             if not success:
@@ -313,26 +315,26 @@ class database:
 
         self.logger.debug('Query view %s', url)
         request = self.couch_request(url)
-        try:
-            data = json.loads(self.opener.open(request).read())
-            if options.get('include_docs'):
-                rows = [r['doc'] for r in data.get('rows', [])]
-            elif design_doc == 'unique':
-                rows = [r['key'] for r in data.get('rows', [])]
-            else:
-                rows = [r['value'] for r in data.get('rows', [])]
 
-            if with_total_rows:
-                total_rows = data.get('total_rows', 0)
-                return {'rows': rows, 'total_rows': total_rows}
+        data = self.opener.open(request).read(self.MAX_READ)
 
-            return rows
-        except Exception as ex:
-            self.logger.error('Error querying view %s: %s', url, ex)
-            if with_total_rows:
-                return {'rows': [], 'total_rows': 0}
+        # Tell the user when MAX_READ is reached
+        if len(data) == self.MAX_READ:
+            raise ValueError('The database returned too much data')
 
-            return []
+        data = json.loads(data)
+        if options.get('include_docs'):
+            rows = [r['doc'] for r in data.get('rows', [])]
+        elif design_doc == 'unique':
+            rows = [r['key'] for r in data.get('rows', [])]
+        else:
+            rows = [r['value'] for r in data.get('rows', [])]
+
+        if with_total_rows:
+            total_rows = data.get('total_rows', 0)
+            return {'rows': rows, 'total_rows': total_rows}
+
+        return rows
 
     def get_all(self, page=-1, limit=20, with_total_rows=False):
         """
@@ -430,8 +432,10 @@ class database:
 
     def search(self, query_dict, page=0, limit=20, include_fields=None, total_rows=False, sort=None, sort_asc=True):
         """
-        Query couchdb-lucene with given query dict
-        Return a dict of results "rows" and number of "total_rows"
+        Query couchdb-lucene with given query dict. By default, returns a list of dicts.
+        If total_rows is True, returns a dict of results "rows" and number of "total_rows" instead.
+
+        Raises on error.
         """
         limit, skip = self.pagify(page, limit)
         query = self.make_query(query_dict)
@@ -466,29 +470,37 @@ class database:
                                              data=options)
         for attempt in range(1, self.max_attempts + 1):
             try:
-                data = self.opener.open(lucene_request)
-                data = json.loads(data.read())
-                if total_rows:
-                    return {'rows': [r['doc'] for r in data.get('rows', [])],
-                            'total_rows': data.get('total_rows', 0)}
-
-                return [r['doc'] for r in data.get('rows', [])]
-
+                data = self.opener.open(lucene_request).read(self.MAX_READ)
             except urllib2.HTTPError as http_error:
                 code = http_error.code
                 self.logger.error('HTTP error %s %s: %s', url, options, http_error)
                 if 400 <= code < 500:
                     # If it's HTTP 4xx - bad request, no point in retry
-                    break
+                    raise
 
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
+                else:
+                    raise
             except Exception as ex:
                 self.logger.error('Error %s %s: %s', url, options, ex)
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
+                else:
+                    raise
+
+            # Tell the user when MAX_READ is reached
+            if len(data) == self.MAX_READ:
+                raise ValueError('The database returned too much data')
+
+            data = json.loads(data)
+            if total_rows:
+                return {'rows': [r['doc'] for r in data.get('rows', [])],
+                        'total_rows': data.get('total_rows', 0)}
+
+            return [r['doc'] for r in data.get('rows', [])]
 
         if total_rows:
             return {'rows': [],

--- a/mcm/rest_api/ControlActions.py
+++ b/mcm/rest_api/ControlActions.py
@@ -124,17 +124,20 @@ class Search(RESTResource):
             for mccm in mccms:
                 args['prepid__'].extend(mccm.get('generated_chains', []).keys())
 
-        if not args and not sort_on:
-            # If there are no args, use simpler fetch
-            res = database.get_all(page, limit, with_total_rows=True)
-        else:
-            # Add types to arguments
-            args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
-            # Construct the complex query
-            res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
+        try:
+            if not args and not sort_on:
+                # If there are no args, use simpler fetch
+                res = database.get_all(page, limit, with_total_rows=True)
+            else:
+                # Add types to arguments
+                args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
+                # Construct the complex query
+                res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
 
-        res['results'] = res.pop('rows', [])
-        return self.output_text(res, 200, {'Content-Type': 'application/json'})
+            res['results'] = res.pop('rows', [])
+            return self.output_text(res, 200, {'Content-Type': 'application/json'})
+        except Exception as e:
+            return self.output_text({'message': str(e)}, 500, {'Content-Type': 'application/json'})
 
 
 class CacheInfo(RESTResource):

--- a/mcm/rest_api/ControlActions.py
+++ b/mcm/rest_api/ControlActions.py
@@ -124,21 +124,23 @@ class Search(RESTResource):
             for mccm in mccms:
                 args['prepid__'].extend(mccm.get('generated_chains', []).keys())
 
-        try:
-            if not args and not sort_on:
-                # If there are no args, use simpler fetch
-                res = database.get_all(page, limit, with_total_rows=True)
-            else:
-                # Add types to arguments
-                args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
-                # Construct the complex query
-                res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
+        if not args and not sort_on:
+            # If there are no args, use simpler fetch
+            res = database.get_all(page, limit, with_total_rows=True)
+        else:
+            # Add types to arguments
+            args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
+            # Construct the complex query
+            res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
 
-            res['results'] = res.pop('rows', [])
-            return self.output_text(res, 200, {'Content-Type': 'application/json'})
-        except Exception as e:
-            return self.output_text({'message': str(e)}, 500, {'Content-Type': 'application/json'})
+        response_code = 200
+        error_message = res.get('message')
+        if error_message and 'The database returned too much data' in error_message:
+            # The client performed a query that outbounds the limit.
+            response_code = 400
 
+        res['results'] = res.pop('rows', [])
+        return self.output_text(res, response_code, {'Content-Type': 'application/json'})
 
 class CacheInfo(RESTResource):
 


### PR DESCRIPTION
Patch for: https://github.com/cms-PdmV/cmsPdmV/pull/1142

Limit database responses to 10MB to avoid consuming all memory on returning a response. Instead of raising a `ValueError` that may not be caught by other endpoints or internal functions, include an optional message on the database response to indicate errors related to the maximum response size for database queries.