### PR TITLE
Skip not valid restriction on forced inspection

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -2347,7 +2347,7 @@ class request(json_base):
                         self.set_attribute('output_dataset', collected)
                         self.set_attribute('completed_events', counted)
 
-                    if not valid:
+                    if not valid and not force:
                         not_good.update({'message' : 'Not all outputs are valid'})
                         saved = db.save(self.json())
                         return not_good


### PR DESCRIPTION
Fixes: https://github.com/cms-PdmV/cmsPdmV/issues/1162

Regarding inspection for submitted requests, skip the constraint about having all output datasets in `VALID` status if the inspection is forced.