### PR TITLE
Allow admins to update the `cmssw_release` in the edit form

### DIFF
--- a/mcm/scripts/edit_controller.js
+++ b/mcm/scripts/edit_controller.js
@@ -20,7 +20,7 @@ angular.module('testApp').controller('resultCtrl',
         $scope.type_list = ["MCReproc","Prod","LHE"];
         break;
       case "requests":
-        $scope.not_editable_list = ["Cmssw release", "Prepid", "Member of campaign", "Pwg", "Status", "Approval", "Type", "Priority", "Completion date", "Member of chain", "Config id", "Flown with", "Reqmgr name", "Completed events","Energy", "Version"]; //user non-editable columns
+        $scope.not_editable_list = ["Prepid", "Member of campaign", "Pwg", "Status", "Approval", "Type", "Priority", "Completion date", "Member of chain", "Config id", "Flown with", "Reqmgr name", "Completed events","Energy", "Version"]; //user non-editable columns
         var promise = $http.get("restapi/requests/editable/"+$scope.prepid)
         promise.then(function(data){
           $scope.parseEditableObject(data.data.results);

--- a/mcm/scripts/edit_many_controller.js
+++ b/mcm/scripts/edit_many_controller.js
@@ -24,8 +24,8 @@ angular.module('testApp').controller('resultsCtrl',
     if($scope.dbName == "requests")
     {
       // get the editable -> set false in list
-      $scope.not_editable_list = ["Cmssw release", "Prepid", "Member of campaign", "Pwg", "Status", "Approval", "Type", "Priority", "Completion date", "Member of chain", "Config id", "Flown with", "Reqmgr name", "Completed events","Energy", "Version", "History"]; //user non-editable columns
-      $scope.non_multiple_editable= ["Cmssw release", "Prepid", "Member of campaign", "Pwg", "Status", "Approval", "Type", "Priority", "Completion date", "Member of chain", "Config id", "Flown with", "Reqmgr name", "Completed events","Energy", "Version", "History"]; //user non-editable columns
+      $scope.not_editable_list = ["Prepid", "Member of campaign", "Pwg", "Status", "Approval", "Type", "Priority", "Completion date", "Member of chain", "Config id", "Flown with", "Reqmgr name", "Completed events","Energy", "Version", "History"]; //user non-editable columns
+      $scope.non_multiple_editable= ["Prepid", "Member of campaign", "Pwg", "Status", "Approval", "Type", "Priority", "Completion date", "Member of chain", "Config id", "Flown with", "Reqmgr name", "Completed events","Energy", "Version", "History"]; //user non-editable columns
       var promise = $http.get("restapi/requests/editable/"+$scope.prepid)
       promise.then(function(data)
       {


### PR DESCRIPTION
Fixes: https://github.com/cms-PdmV/cmsPdmV/issues/1171

This permission is already set in the `non_editable_request` configuration attribute stored in the `settings` database. Remove the label related to this attribute on the UI side.