### PR TITLE
Allow `production_managers` to edit more attributes for a request

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -210,6 +210,8 @@ class request(json_base):
                 # "validation-validation", "define-" and "approve-" requests
                 editable['input_dataset'] = True
                 editable['extension'] = True
+                editable['dataset_name'] = True
+                editable['process_string'] = True
 
             if self.current_user_level == 2 and self.get_attribute('approval') in ('validation', 'define', 'approve'):
                 # Allow generator conveners to edit dataset name for


### PR DESCRIPTION
Allow this role to edit the `dataset_name` and the `process_string`.

This behavior was already authorized for `generator_conveners` and `generator_contacts` in #1117 