### PR TITLE
Include support for `gssapi-with-mic` for authenticating SSH sessions

### DIFF
--- a/mcm/optional-requirements.txt
+++ b/mcm/optional-requirements.txt
@@ -1,0 +1,4 @@
+# Packages for enabling `gssapi_with_mic` for
+# authenticating SSH sessions.
+gssapi==1.9.0
+pyasn1==0.6.1

--- a/mcm/tools/locator.py
+++ b/mcm/tools/locator.py
@@ -282,3 +282,11 @@ class locator:
             return server, port
 
         return "cernmx.cern.ch", 25
+
+    def use_gssapi_with_mic_for_auth(self):
+        """
+        In case `gssapi_with_mic` is available, use a Kerberos ticket
+        for authenticating SSH sessions. Enable this behavior by
+        setting the environment variable: $MCM_GSSAPI_WITH_MIC.
+        """
+        return bool(os.getenv("MCM_GSSAPI_WITH_MIC"))


### PR DESCRIPTION
Enable both `SSH` executors to authenticate to the remote host using Kerberos tickets via `gssapi-with-mic`.

Remember to install the optional packages `gssapi` and `pyasn1` to enable `paramiko` to use this authentication strategy.