### PR TITLE
Remove constraint on memory for 1 core validation jobs

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -446,12 +446,6 @@ class request(json_base):
                     'validation',
                     'The request type: %s should have a positive or null mcdb id' % (self.get_attribute('type')))
 
-        if self.get_core_num() == 1 and int(self.get_attribute("memory")) > 4000:
-            raise self.WrongApprovalSequence(
-                self.get_attribute('status'),
-                'validation',
-                'Single core request should use <= 4GB memory. Try increasing the number of cores')
-
         # Do not allow to validate if there are collisions
         self.check_for_collisions()
 


### PR DESCRIPTION
Fixes: #1196 

The `memory` attribute will be overwritten/corrected on the submission phase with the validation results, so this check is not required. For more details, see:

- https://github.com/cms-PdmV/cmsPdmV/issues/1196