### PR TITLE
Check on action parameter flag during chain submission

### DIFF
--- a/mcm/rest_api/ChainedRequestActions.py
+++ b/mcm/rest_api/ChainedRequestActions.py
@@ -817,7 +817,10 @@ class TaskChainDict(RESTResource):
             # so it would be task_prepid-of-current-request same as in top
             __req_id = mcm_crs[0]['chain'][mcm_crs[0]['step']]
             task_name = 'task_' + __req_id
-
+        
+        # Filter only chained request ready to be used
+        mcm_crs = [cr for cr in mcm_crs if cr.get('action_parameters').get('flag')]
+        
         if len(mcm_crs) == 0:
             return {}
 

--- a/mcm/tools/handlers.py
+++ b/mcm/tools/handlers.py
@@ -462,6 +462,12 @@ class ChainRequestInjector(SubmissionsBase):
         if len(mcm_crs) == 0:
             return
 
+        # Filter only chained request ready to be used
+        mcm_crs = [
+            cr
+            for cr in mcm_crs
+            if cr.get('action_parameters').get('flag')
+        ]
         mcm_requests = []
         for cr in mcm_crs:
             mcm_cr = chained_request(cr)

--- a/mcm/tools/handlers.py
+++ b/mcm/tools/handlers.py
@@ -458,16 +458,16 @@ class ChainRequestInjector(SubmissionsBase):
             task_name = 'task_' + current_step_prepid
 
         batch_name = 'Task_' + mcm_request['member_of_campaign']
-
-        if len(mcm_crs) == 0:
-            return
-
         # Filter only chained request ready to be used
         mcm_crs = [
             cr
             for cr in mcm_crs
             if cr.get('action_parameters').get('flag')
         ]
+
+        if len(mcm_crs) == 0:
+            return
+
         mcm_requests = []
         for cr in mcm_crs:
             mcm_cr = chained_request(cr)


### PR DESCRIPTION
the current chain submission does not check on the validity of a chain during injection. this validity is set by action_parameter.flag set to True for active chain, and False for inactive ones