### PR TITLE
Change thread count selection policy

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -3063,7 +3063,7 @@ class request(json_base):
 
             validation_info = sorted(validation_info, key=lambda v: v['threads'])
             self.logger.info('Validation info (by threads) %s', dumps(validation_info, indent=2, sort_keys=True))
-            validation_info = [v for v in validation_info if v['cpu_efficiency'] > max_efficiency - filter_efficiency_margin]
+            validation_info = [v for v in validation_info if v['cpu_efficiency'] > cpu_efficiency_threshold]
             self.logger.info('Validation info after filter (by cpu eff) %s', dumps(validation_info, indent=2, sort_keys=True))
             if validation_info:
                 validation_info = validation_info[-1]


### PR DESCRIPTION
the previous policy is able o select marginally better cpu efficiency over higher thread count. the new policy allows to select the max thread within a margin of the best cpu effiiciency for low filter efficiency requests.

requires new parameters

filter_eff_threshold_for_thread_choice = 0.001
filter_eff_margin_for_thread_choice = 0.05

and renaming one:
cpu_efficiency_threshold --> cpu_efficiency_threshold_for_thread_choice 