### PR TITLE
Delete generator parameters for a request

### DIFF
--- a/mcm/rest_api/RequestActions.py
+++ b/mcm/rest_api/RequestActions.py
@@ -333,6 +333,10 @@ class UpdateRequest(RequestRESTResource):
         if requests_events_per_lumi != 0 and (requests_events_per_lumi < 100 or requests_events_per_lumi > 1000):
             return {"results": False, 'message': 'Events per lumi must be 100<=X<=1000 or 0 to use campaign\'s value'}
 
+        new_generator_parameters: list[dict] = mcm_req.get_attribute('generator_parameters')
+        if not new_generator_parameters:
+            return {"results": False, 'message': 'At least one set of generator parameters must be provided!'}
+
         self.logger.info('Updating request %s...' % (mcm_req.get_attribute('prepid')))
 
         # update history

--- a/mcm/scripts/edit.js
+++ b/mcm/scripts/edit.js
@@ -145,30 +145,40 @@ angular.module('testApp').controller('ModalDemoCtrl',
           },
           showData: function() {
             return $scope.showData;
-          }
+          },
+          doNotDelete: function() {
+            return $scope.genParam_data.length <= 1;
+          },
         }
       });
 
-      genParamModal.result.then(function(new_gen_params) {
+      genParamModal.result.then(function(resultData) {
+        let new_gen_params = resultData["data"];
+        let finalAction = resultData["action"];
         _.each(new_gen_params, function(elem,key){
           if (_.isString(elem) && key !="$$hashKey"){
             new_gen_params[key] = parseFloat(elem);
           }
         });
-        if(action == "Edit") {
+        if(finalAction == "Edit") {
           _.each(new_gen_params, function(elem,key){
             if (!isNaN(elem)){
               $scope.genParam_data[index][key] = elem;
             }
           });
+        } else if (finalAction == "Delete") {
+          if ($scope.genParam_data.length > 1) {
+            $scope.genParam_data.splice(index, 1);
+          }
         } else { // Add
           $scope.genParam_data.push(new_gen_params);
         }
       });
     };
 
-    var GeneratorParamsInstandeModal = function($scope, $modalInstance, data, action, showData) {
+    var GeneratorParamsInstandeModal = function($scope, $modalInstance, data, action, showData, doNotDelete) {
       $scope.action = action;
+      $scope.doNotDelete = doNotDelete;
       $scope.gen_params = {
         data: data,
         show: showData
@@ -177,8 +187,12 @@ angular.module('testApp').controller('ModalDemoCtrl',
         $modalInstance.dismiss();
       };
       $scope.saveGenParam = function() {
-        $modalInstance.close($scope.gen_params.data);
+        $modalInstance.close({"data": $scope.gen_params.data, "action": action});
       };
+      $scope.deleteGenParam = function() {
+        // Overwrite the action
+        $modalInstance.close({"data": $scope.gen_params.data, "action": "Delete"});
+      }
     };
 
   // Flows Request params shit
@@ -481,6 +495,7 @@ testApp.directive("generatorParams", function($http){
     '    <div class="modal-footer">'+
     '      <button class="btn btn-success" ng-click="saveGenParam()">Save</button>'+
     '      <button class="btn btn-warning cancel" ng-click="closeGenParam()">Cancel</button>'+
+    '      <button class="btn btn-danger" ng-click="deleteGenParam()" ng-hide="action == \'Add\' || doNotDelete">Delete</button>'+
     '    </div>'+ //end of modal footer
     '  </script>'+///END OF MODAL
     '  <ul ng-repeat="elem in genParam_data">'+


### PR DESCRIPTION
Solves: https://github.com/cms-PdmV/cmsPdmV/issues/1017

Allow users to remove the generator parameters while updating a request. Make sure that at least one version of the parameters is provided.