### PR TITLE
Remove ClearInvalidations `/restapi/invalidations/clear`

### DIFF
--- a/mcm/HTML/invalidations.html
+++ b/mcm/HTML/invalidations.html
@@ -77,9 +77,6 @@
                 <a rel="tooltip" title="Edit invalidation" ng-href="edit?db_name=invalidations&prepid={{objectToId(invalidations_info['object'])}}" ng-hide="role(2);" target="_self">
                   <i class="icon-wrench"></i>
                 </a>
-                <a rel="tooltip" title="Clear invalidation" ng-click="do_action(invalidations_info['_id'], 'clear');" ng-hide="role(3);" ng-href="#">
-                  <i class="icon-fire"></i>
-                </a>
                 <a rel="tooltip" title="Announce invalidation" ng-click="do_action(invalidations_info['_id'], 'announce');" ng-hide="role(3);" ng-href="#">
                   <i class="icon-bullhorn"></i>
                 </a>
@@ -112,9 +109,6 @@
       <div class="span4">
         <span>
           Multiple selection buttons
-          <a ng-click="do_action(selected_objects, 'clear');" rel="tooltip" ng-hide="role(3);" title="Clear selected invalidations" ng-href="#">
-            <i class="icon-fire"></i>
-          </a>
           <a ng-click="do_action(selected_objects, 'announce');" rel="tooltip" ng-hide="role(3);" title="Announce selected invalidations" ng-href="#">
             <i class="icon-bullhorn"></i>
           </a>

--- a/mcm/main.py
+++ b/mcm/main.py
@@ -7,7 +7,7 @@ from rest_api.ChainedRequestActions import ForceChainReqToDone, ForceStatusDoneT
 from rest_api.FlowActions import CreateFlow, UpdateFlow, DeleteFlow, GetFlow, ApproveFlow, CloneFlow
 from rest_api.UserActions import GetUserRole, AddRole, AskRole, ChangeRole, GetUser, SaveUser, GetUserPWG, NotifyPWG
 from rest_api.BatchActions import HoldBatch, GetBatch, AnnounceBatch, InspectBatches, ResetBatch, NotifyBatch
-from rest_api.InvalidationActions import GetInvalidation, DeleteInvalidation, AnnounceInvalidations, ClearInvalidations, AcknowledgeInvalidation, PutHoldtoNewInvalidations, PutOnHoldInvalidation
+from rest_api.InvalidationActions import GetInvalidation, DeleteInvalidation, AnnounceInvalidations, AcknowledgeInvalidation, PutHoldtoNewInvalidations, PutOnHoldInvalidation
 from rest_api.DashboardActions import GetLocksInfo, GetBjobs, GetLogFeed, GetLogs, GetRevision, GetStartTime, GetQueueInfo
 from rest_api.MccmActions import GetMccm, UpdateMccm, CreateMccm, DeleteMccm, CancelMccm, GetEditableMccmFields, GenerateChains, MccMReminderProdManagers, MccMReminderGenConveners, MccMReminderGenContacts, CalculateTotalEvts, CheckIfAllApproved, NotifyMccm
 from rest_api.SettingsActions import GetSetting, UpdateSetting, SaveSetting
@@ -335,7 +335,6 @@ api.add_resource(NotifyBatch, '/restapi/batches/notify')
 api.add_resource(GetInvalidation, '/restapi/invalidations/get/<string:invalidation_id>')
 api.add_resource(DeleteInvalidation, '/restapi/invalidations/delete/<string:invalidation_id>')
 api.add_resource(AnnounceInvalidations, '/restapi/invalidations/announce')
-api.add_resource(ClearInvalidations, '/restapi/invalidations/clear')
 api.add_resource(AcknowledgeInvalidation, '/restapi/invalidations/acknowledge/<string:invalidation_id>')
 api.add_resource(PutOnHoldInvalidation, '/restapi/invalidations/new_to_hold')
 api.add_resource(PutHoldtoNewInvalidations, '/restapi/invalidations/hold_to_new')


### PR DESCRIPTION
This endpoint is not required anymore and it is currently dead code. It used to serve to the purpose to send the invalidation to the last stage without actually invalidating the dataset. For more details, see:

- https://github.com/cms-PdmV/cmsPdmV/issues/1163