### PR TITLE
Decrease permissions for `Dashboard`

### DIFF
--- a/mcm/rest_api/DashboardActions.py
+++ b/mcm/rest_api/DashboardActions.py
@@ -10,7 +10,7 @@ from tools.locator import locator
 
 class GetBjobs(RESTResource):
 
-    access_limit = access_rights.user
+    access_limit = access_rights.generator_contact
 
     def __init__(self):
         self.before_request()
@@ -44,7 +44,7 @@ class GetBjobs(RESTResource):
 
 class GetLogFeed(RESTResource):
 
-    access_limit = access_rights.user
+    access_limit = access_rights.production_manager
 
     def __init__(self):
         self.before_request()
@@ -127,7 +127,7 @@ class GetStartTime(RESTResource):
 
 class GetLogs(RESTResource):
 
-    access_limit = access_rights.user
+    access_limit = access_rights.production_manager
 
     def __init__(self):
         self.path = locator().logs_folder()
@@ -171,7 +171,7 @@ class GetLocksInfo(RESTResource):
 
 class GetQueueInfo(RESTResource):
 
-    access_limit = access_rights.user
+    access_limit = access_rights.generator_contact
 
     def __init__(self):
         self.before_request()

--- a/mcm/scripts/dashboard_controller.js
+++ b/mcm/scripts/dashboard_controller.js
@@ -79,6 +79,9 @@ angular.module('testApp').controller('resultsCtrl',
         $scope.update["success"] = false;
         $scope.update["fail"] = true;
         $scope.update["status_code"] = data.status;
+        if (data.data.message) {
+          $scope.results = data.data.message;
+        }
       });
 
       var promise2 = $http.get("restapi/dashboard/queue_info");
@@ -157,7 +160,13 @@ angular.module('testApp').controller('resultsCtrl',
         $scope.logs.list =  data.data.results;
         $scope.selectedLog = $scope.logs.list[0];
       }, function(data){
-        alert("Error getting logs list: " +data.status);
+        $scope.update["success"] = false;
+        $scope.update["fail"] = true;
+        $scope.update["status_code"] = data.status;
+        console.error("Error getting logs list - Unable to display logs: " + data.status);
+        if (data.data.message) {
+          $scope.logs.results = data.data.message;
+        }
       });
     };
 


### PR DESCRIPTION
Do not allow users with the `user` role to consume this endpoint to mitigate a potential information disclosure about the application runtime environment and internals. Allow users with role `generator_contact` or higher to see the validation jobs and logs only for those with role `production_manager` or higher.