### PR TITLE
Query for started campaigns on the campaign tab

### DIFF
--- a/mcm/HTML/navbar_template.html
+++ b/mcm/HTML/navbar_template.html
@@ -2,7 +2,7 @@
   <div class="navbar-inner">
     <ul class="nav">
       <li ng-class='{ "active": dbName=="campaigns"}'>
-        <a ng-href='campaigns' target="_self">Campaign <i class="icon-book"></i></a>
+        <a ng-href='campaigns?status=started' target="_self">Campaign <i class="icon-book"></i></a>
       </li>
       <li class="divider-vertical"></li>
       <li ng-class='{ "active": dbName=="chained_campaigns"}'>


### PR DESCRIPTION
Completes: https://github.com/cms-PdmV/cmsPdmV/issues/1209

By default, when users click on this icon, display only the `started` campaigns