### PR TITLE
Change priority: Propagate errors from failed requests

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1891,15 +1891,20 @@ class request(json_base):
                 else:
                     cmsweb_url = 'https://cmsweb.cern.ch'
 
-                connection = ConnectionWrapper(host=cmsweb_url, keep_open=True)
-                for reqmgr_name in reqmgr_names:
-                    self.logger.info('Changing "%s" priority to %s', reqmgr_name, new_priority)
-                    response = connection.api('PUT',
-                                              '/reqmgr2/data/request/%s' % (reqmgr_name),
-                                              {'RequestPriority': new_priority})
-                    self.logger.debug(response)
-
-                connection.close()
+                with ConnectionWrapper(host=cmsweb_url, keep_open=True) as connection:
+                    for reqmgr_name in reqmgr_names:
+                        self.logger.info('Changing "%s" priority to %s', reqmgr_name, new_priority)
+                        response = connection.api('PUT',
+                                                '/reqmgr2/data/request/%s' % (reqmgr_name),
+                                                {'RequestPriority': new_priority})
+                        self.logger.debug(response)
+                        if not response:
+                            # Unable to perform the HTTP request!
+                            return False
+                        if isinstance(response, tuple):
+                            _, status_code = response
+                            if status_code != 200:
+                                return False
 
             return self.modify_priority(new_priority)
 

--- a/mcm/tools/connection_wrapper.py
+++ b/mcm/tools/connection_wrapper.py
@@ -51,6 +51,7 @@ class ConnectionWrapper():
     def __enter__(self):
         self.logger.debug('Entering context, host: %s', self.host_url)
         self.keep_open = True
+        return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         self.logger.debug('Exiting context, host: %s', self.host_url)
@@ -118,7 +119,7 @@ class ConnectionWrapper():
                                       method,
                                       url,
                                       response_to_return)
-                    return response_to_return
+                    return response_to_return, response.status
 
                 if not self.keep_open:
                     self.close()
@@ -129,7 +130,7 @@ class ConnectionWrapper():
                                   self.host_url,
                                   url,
                                   end_time - start_time)
-                return response_to_return
+                return response_to_return, response.status
             except Exception as ex:
                 raise ex
                 self.logger.error('Exception while doing a %s to %s: %s',


### PR DESCRIPTION
Fixes: https://github.com/cms-PdmV/cmsPdmV/issues/1223

If an HTTP response has a status code different from 200, return `False` instead of just bypassing the issue.