### PR TITLE
Avoid validation issues with requests having more than one sequence

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1677,6 +1677,9 @@ class request(json_base):
                 sequence_dict=sequence_dict,
                 threads=threads
             )
+            if index != len(sequences) - 1 and "number_out" in sequence_dict and "number" in sequence_dict:
+                sequence_dict["number_out"] = sequence_dict["number"]
+
             if configs_to_upload and "number_out" in sequence_dict:
                 # This is related to the upload fragment procedure to
                 # ReqMgr2, remove the `--number_out` parameter in case


### PR DESCRIPTION
Fixes: #1230 

Set the same number of events for both `--number` and `--number_out` for intermediate sequences that are not the last.