### PR TITLE
Show more details to users on failed validations

### DIFF
--- a/mcm/tools/locator.py
+++ b/mcm/tools/locator.py
@@ -291,3 +291,7 @@ class locator:
             return custom_wmcontrol_path
 
         return "/afs/cern.ch/cms/PPD/PdmV/tools/wmcontrol"
+
+    def get_validation_failed_log_folder(self):
+        """Return the folder to store validation failed records for further inspection."""
+        return os.getenv("MCM_VALIDATION_FAILED_EOS_FOLDER")


### PR DESCRIPTION
Completes: https://github.com/cms-PdmV/cmsPdmV/issues/1235

This PR modifies the validation failed message to include the expected parameters, the real measurements, and the number of threads used for an attempt in the first stage. Also, it allows moving files related to a failed validation attempt to `/eos` to inspection instead of just removing them