### PR TITLE
Fix: Permission errors for creating folder in /eos for validation records

### DIFF
--- a/mcm/automatic_scripts/validation/validation_control.py
+++ b/mcm/automatic_scripts/validation/validation_control.py
@@ -1310,7 +1310,7 @@ class ValidationControl():
             return
 
         # Remove the old directory
-        _, _ = self.ssh_executor.execute_command(['rmdir %s' % (item_directory)])
+        _, _ = self.ssh_executor.execute_command(['rm -rf %s' % (item_directory)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Related to: https://github.com/cms-PdmV/cmsPdmV/pull/1237

Change directory and then create the remaining folders. Also, fix the deletion command for the initial validation folder.