### PR TITLE
Compute time/event in the one-thread hypothesis 

### DIFF
--- a/mcm/HTML/requests.html
+++ b/mcm/HTML/requests.html
@@ -398,7 +398,6 @@
                     <span class="label label-info" ng-show="data[column.db_name]" title="seconds">s</span>
                    </li>
                 </ul>
-                <span class="label label-info" ng-show="data[column.db_name]" title="seconds">s<span>
               </div>
               <div ng-switch-when="filter_efficiency" align="center">
                 {{data["generator_parameters"].slice(-1)[0]["filter_efficiency"]}}

--- a/mcm/HTML/requests.html
+++ b/mcm/HTML/requests.html
@@ -392,7 +392,12 @@
                 <span class="label label-info" ng-show="data[column.db_name]" title="Kegabytes">kB<span>
               </div>
               <div ng-switch-when="time_event" align="center">
-                {{data[column.db_name] | number:4}}
+                <ul ng-repeat="time_event_sequence in data[column.db_name] track by $index">
+                  <li>
+                    {{ time_event_sequence | number:4 }}
+                    <span class="label label-info" ng-show="data[column.db_name]" title="seconds">s</span>
+                   </li>
+                </ul>
                 <span class="label label-info" ng-show="data[column.db_name]" title="seconds">s<span>
               </div>
               <div ng-switch-when="filter_efficiency" align="center">

--- a/mcm/HTML/requests.html
+++ b/mcm/HTML/requests.html
@@ -334,6 +334,7 @@
                               <li>Peak Value RSS: {{sequence.peak_value_rss | number:2}} MB</li>
                               <li>Filter efficiency: {{(sequence.filter_efficiency) * 100 | number:1}} %</li>
                               <li>Time per event: {{sequence.time_per_event | number:4}} s</li>
+			      <li>Time per event (single thread): {{sequence.time_per_event_onethread | number:4}} s</li>
                               <li>Size per event: {{sequence.size_per_event | number:4}} kB</li>
                               <li ng-if="sequence.cpu_name">CPU Name: {{sequence.cpu_name}}</li>
                             </ul>
@@ -346,6 +347,7 @@
                           <li>Peak Value RSS: {{threadsResult[0].peak_value_rss | number:2}} MB</li>
                           <li>Filter efficiency: {{(threadsResult[0].filter_efficiency) * 100 | number:1}} %</li>
                           <li>Time per event: {{threadsResult[0].time_per_event | number:4}} s</li>
+			  <li>Time per event (single thread): {{threadsResult[0].time_per_event_onethread | number:4}} s</li>
                           <li>Size per event: {{threadsResult[0].size_per_event | number:4}} kB</li>
                           <li ng-if="threadsResult[0].cpu_name">CPU Name: {{threadsResult[0].cpu_name}}</li>
                         </ul>
@@ -356,6 +358,7 @@
                           <li>Peak Value RSS: {{threadsResult.peak_value_rss | number:2}} MB</li>
                           <li>Filter efficiency: {{(threadsResult.filter_efficiency) * 100 | number:1}} %</li>
                           <li>Time per event: {{threadsResult.time_per_event | number:4}} s</li>
+                          <li>Time per event (single thread): {{threadsResult.time_per_event_onethread | number:4}} s</li>
                           <li>Size per event: {{threadsResult.size_per_event | number:4}} kB</li>
                           <li ng-if="threadsResult.cpu_name">CPU Name: {{threadsResult.cpu_name}}</li>
                         </ul>
@@ -389,7 +392,7 @@
                 <span class="label label-info" ng-show="data[column.db_name]" title="Kegabytes">kB<span>
               </div>
               <div ng-switch-when="time_event" align="center">
-                {{data[column.db_name]}}
+                {{data[column.db_name] | number:4}}
                 <span class="label label-info" ng-show="data[column.db_name]" title="seconds">s<span>
               </div>
               <div ng-switch-when="filter_efficiency" align="center">

--- a/mcm/automatic_scripts/validation/validation_control.py
+++ b/mcm/automatic_scripts/validation/validation_control.py
@@ -273,7 +273,7 @@ class ValidationControl():
         time_per_event_margin = settings.get_value('timing_fraction')
         for sequence_index in range(len(expected)):
             expected_time_per_event = expected[sequence_index]['time_per_event']
-            actual_time_per_event = report[sequence_index]['time_per_event']
+            actual_time_per_event = report[sequence_index]['time_per_event_onethread']
             lower_threshold = expected_time_per_event * (1 - time_per_event_margin)
             upper_threshold = expected_time_per_event * (1 + time_per_event_margin)
             message = ('%s sequence %s/%s expected %.4fs +- %.2f%% (%.4fs - %.4fs) time per '
@@ -382,7 +382,7 @@ class ValidationControl():
         adjusted_time_per_event = []
         for sequence_index in range(len(expected)):
             expected_time_per_event = expected[sequence_index]['time_per_event']
-            actual_time_per_event = report[sequence_index]['time_per_event']
+            actual_time_per_event = report[sequence_index]['time_per_event_onethread']
             adjusted_time_per_event.append((expected_time_per_event + 9 * actual_time_per_event) / 10)
 
         request = self.request_db.get(request_name)
@@ -390,7 +390,7 @@ class ValidationControl():
         self.logger.info('%s expected %s time per event, measured %s, adjusting to %s',
                          request_name,
                          ', '.join(['%.4fs' % (e['time_per_event']) for e in expected]),
-                         ', '.join(['%.4fs' % (r['time_per_event']) for r in report]),
+                         ', '.join(['%.4fs' % (r['time_per_event_onethread']) for r in report]),
                          ', '.join(['%.4fs' % (a) for a in adjusted_time_per_event]))
         self.request_db.save(request)
         return adjusted_time_per_event
@@ -1030,6 +1030,7 @@ class ValidationControl():
         # Estimated events per lumi based on filter efficiency and measured time per event
         estimated_events_per_lumi = (28800 * filter_efficiency / time_per_event) if time_per_event > 0 else 0
         return {'time_per_event': time_per_event,
+                'time_per_event_onethread': time_per_event / threads,
                 'size_per_event': size_per_event,
                 'cpu_efficiency': cpu_efficiency,
                 'estimated_events_per_lumi': estimated_events_per_lumi,

--- a/mcm/automatic_scripts/validation/validation_control.py
+++ b/mcm/automatic_scripts/validation/validation_control.py
@@ -1030,7 +1030,7 @@ class ValidationControl():
         # Estimated events per lumi based on filter efficiency and measured time per event
         estimated_events_per_lumi = (28800 * filter_efficiency / time_per_event) if time_per_event > 0 else 0
         return {'time_per_event': time_per_event,
-                'time_per_event_onethread': time_per_event / threads,
+                'time_per_event_onethread': time_per_event * threads,
                 'size_per_event': size_per_event,
                 'cpu_efficiency': cpu_efficiency,
                 'estimated_events_per_lumi': estimated_events_per_lumi,


### PR DESCRIPTION
Fixes #1238 by adding `time_per_event_onethread` in the report document, and use that value for adjusting the time_event field in the request.
Should eventually help with #1234 that otherwise bounces back and forth from successive run tests.