### PR TITLE
allow some reqmgr bad status to still be considered exceptionnally

### DIFF
--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -2067,6 +2067,13 @@ class request(json_base):
                                      'aborted-archived',
                                      'failed-archived',
                                      'aborted-completed'])
+        ## take this from a setting, of this form
+        #bypass_skippabke_transitions = {
+        #'BPH-RunIII2024Summer24DRPremix-00038' : ['rejected-archived']
+        #}
+        bypass_skippabke_transitions = settings.get_value('bypass_skippabke_transitions')
+        bypass_skippable = bypass_skippabke_transitions.get(prepid,[])
+        skippable_transitions -= set(bypass_skippable)
         total_events = 0
         for reqmgr_name in all_reqmgr_name_list:
             stats_doc = stats_workflows_dict.get(reqmgr_name, None)


### PR DESCRIPTION
as a way to solve #1245 , we can allow some bad reqmgr status to be considered as valid entry in reqmgr_name, and use them as ok source of information. 
to be tested with https://cms-pdmv-prod.web.cern.ch/mcm/requests?prepid=BPH-RunIII2024Summer24DRPremix-00038 somehow